### PR TITLE
Istio Ingress and Kubernetes Ingress configuration and examples

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,11 +50,5 @@ deploy-cmd-pod:
 check-istio-ingress:
 	curl http://localhost:15021/healthz/ready -v
 
-deploy-httpbin-example:
-	kubectl apply -f ./examples/httpbin/deployment.yaml
-
-httpbin-ingress-k8s:
-	kubectl apply -f ./examples/httpbin/k8s-ingress.yaml
-
-httpbin-ingress-istio:
-	kubectl apply -f ./examples/httpbin/istio-ingress.yaml
+install-example:
+	kubectl apply -f ./examples/httpbin

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ install-acp-stack:
 
 install-istio:
 	curl -L https://istio.io/downloadIstio | ISTIO_VERSION=1.9.3 TARGET_ARCH=x86_64  sh -
-	./istio-1.9.3/bin/istioctl install --set profile=demo -y
+	./istio-1.9.3/bin/istioctl install -f ./config/ce-istio-profile.yaml -y
 	kubectl label namespace default istio-injection=enabled
 	rm -rf ./istio-1.9.3
 	
@@ -46,3 +46,15 @@ delete-cluster:
 ## helpers
 deploy-cmd-pod:
 	kubectl apply -f https://raw.githubusercontent.com/istio/istio/release-1.9/samples/sleep/sleep.yaml
+
+check-istio-ingress:
+	curl http://localhost:15021/healthz/ready -v
+
+deploy-httpbin-example:
+	kubectl apply -f ./examples/httpbin/deployment.yaml
+
+httpbin-ingress-k8s:
+	kubectl apply -f ./examples/httpbin/k8s-ingress.yaml
+
+httpbin-ingress-istio:
+	kubectl apply -f ./examples/httpbin/istio-ingress.yaml

--- a/config/ce-istio-profile.yaml
+++ b/config/ce-istio-profile.yaml
@@ -1,0 +1,79 @@
+apiVersion: install.istio.io/v1alpha1
+kind: IstioOperator
+spec:
+  meshConfig:
+    accessLogFile: /dev/stdout
+  components:
+    egressGateways:
+    - name: istio-egressgateway
+      enabled: true
+      k8s:
+        resources:
+          requests:
+            cpu: 10m
+            memory: 40Mi
+
+    ingressGateways:
+    - name: istio-ingressgateway
+      enabled: true
+      k8s:
+        resources:
+          requests:
+            cpu: 10m
+            memory: 40Mi
+        service:
+          type: NodePort
+          ports:
+            ## You can add custom gateway ports in user values overrides, but it must include those ports since helm replaces.
+            # Note that AWS ELB will by default perform health checks on the first port
+            # on this list. Setting this to the health check port will ensure that health
+            # checks always work. https://github.com/istio/istio/issues/12503
+            # Valid port range 30000-32767
+            - port: 15021
+              nodePort: 30002
+              targetPort: 15021
+              name: status-port
+            - port: 80
+              nodePort: 31080
+              targetPort: 8080
+              name: http2
+            - port: 443
+              nodePort: 31443
+              targetPort: 8443
+              name: https
+            - port: 31400
+              nodePort: 30400
+              targetPort: 31400
+              name: tcp
+              # This is the port where sni routing happens
+            - port: 15443
+              nodePort: 32443
+              targetPort: 15443
+              name: tls           
+    pilot:
+      k8s:
+        env:
+          - name: PILOT_TRACE_SAMPLING
+            value: "100"
+        resources:
+          requests:
+            cpu: 10m
+            memory: 100Mi
+
+  values:
+    global:
+      proxy:
+        resources:
+          requests:
+            cpu: 10m
+            memory: 40Mi
+
+    pilot:
+      autoscaleEnabled: false
+
+    gateways:
+      istio-egressgateway:
+        autoscaleEnabled: false
+      istio-ingressgateway:
+        autoscaleEnabled: false
+        type: NodePort

--- a/config/kind-cluster-config.yaml
+++ b/config/kind-cluster-config.yaml
@@ -3,6 +3,19 @@ apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
   - role: control-plane
     extraPortMappings:
+#ACP Ingress controler
       - containerPort: 30443
         hostPort: 8443
+        protocol: TCP
+#Istio Ingres status endpoint
+      - containerPort: 30002
+        hostPort: 15021
+        protocol: TCP
+#Istio Ingres http port
+      - containerPort: 31080
+        hostPort: 9080
+        protocol: TCP
+#Istio Ingres https port
+      - containerPort: 31443
+        hostPort: 9443
         protocol: TCP

--- a/examples/httpbin/deployment.yaml
+++ b/examples/httpbin/deployment.yaml
@@ -1,0 +1,41 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: httpbin
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: httpbin
+spec:
+  selector:
+    app: httpbin
+  ports:
+  - port: 80
+    name: http
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: httpbin
+  labels:
+    app: httpbin
+  annotations:
+    services.k8s.cloudentity.com/spec-url: "http://httpbin.org/spec.json"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: httpbin
+  template:
+    metadata:
+      labels:
+        app: httpbin
+    spec:
+      serviceAccountName: httpbin
+      containers:
+      - name: httpbin
+        image: "kennethreitz/httpbin"
+        ports:
+        - containerPort: 80
+          name: http

--- a/examples/httpbin/istio-ingress.yaml
+++ b/examples/httpbin/istio-ingress.yaml
@@ -1,0 +1,34 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: Gateway
+metadata:
+  name: httpbin-gateway
+spec:
+  selector:
+    istio: ingressgateway # use Istio default gateway implementation
+  servers:
+  - port:
+      number: 80
+      name: http
+      protocol: HTTP
+    hosts:
+    - "httpbin.ingress.istio"
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: httpbin-virtual
+spec:
+  hosts:
+  - "httpbin.ingress.istio"
+  gateways:
+  - httpbin-gateway
+  http:
+  - match:
+    - uri:
+        prefix: /get
+    route:
+    - destination:
+        port:
+          number: 80
+        host: httpbin
+

--- a/examples/httpbin/k8s-ingress.yaml
+++ b/examples/httpbin/k8s-ingress.yaml
@@ -1,0 +1,15 @@
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: istio
+  name: ingress
+spec:
+  rules:
+  - host: httpbin.ingress.k8s
+    http:
+      paths:
+      - path: /*
+        backend:
+          serviceName: httpbin
+          servicePort: 80


### PR DESCRIPTION
Configuration of the Istio Ingress and Kubernetes Ingress for example httpbin services to showcase how Cloudentity Authorization can be applied for ingress traffic.

Added:
* New Node ports configuration for Kind
* Istio ingress service configured to use NodePort instead of LoadBalancer ( to make it work with Kind)
* Deployment files for the example service
* Ingress configuration files for both Istio Ingress Gateway as well as traditional Kubernetes Ingress for httpbin example service
* additional helpers in Makefile
 