### PR TITLE
Separate ingress controller and acp stack make targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ ifneq (,$(wildcard ./.env))
     export
 endif
 
-all: create-cluster prepare-helm prepare-cluster install-acp-stack
+all: create-cluster prepare-helm prepare-cluster install-ingress-controller install-acp-stack
 
 create-cluster:
 	kind create cluster --name acp --config=./config/kind-cluster-config.yaml
@@ -21,18 +21,20 @@ prepare-cluster:
 		--docker-username=${DOCKER_USER} \
 		--docker-password=${DOCKER_PWD}
 
+install-ingress-controller:
+	helm upgrade --install ingress-nginx ingress-nginx/ingress-nginx --values ./values/ingress-nginx.yaml -n nginx
+	kubectl -n nginx wait deploy/ingress-nginx-controller --for condition=available --timeout=10m
+
 install-acp-stack:
 	helm upgrade --install acp acp/kube-acp-stack --values ./values/kube-acp-stack.yaml -n acp-system
 	kubectl -n acp-system wait deploy/acp --for condition=available --timeout=10m
-	helm upgrade --install ingress-nginx ingress-nginx/ingress-nginx --values ./values/ingress-nginx.yaml -n nginx
-	kubectl -n nginx wait deploy/ingress-nginx-controller --for condition=available --timeout=10m
 
 install-istio:
 	curl -L https://istio.io/downloadIstio | ISTIO_VERSION=1.9.3 TARGET_ARCH=x86_64  sh -
 	./istio-1.9.3/bin/istioctl install -f ./config/ce-istio-profile.yaml -y
 	kubectl label namespace default istio-injection=enabled
 	rm -rf ./istio-1.9.3
-	
+
 watch:
 	watch kubectl get pods -A
 

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,9 @@ ifneq (,$(wildcard ./.env))
     export
 endif
 
-all: create-cluster prepare-helm prepare-cluster install-ingress-controller install-acp-stack
+all: prepare install-acp-stack
+
+prepare: create-cluster prepare-helm prepare-cluster install-ingress-controller
 
 create-cluster:
 	kind create cluster --name acp --config=./config/kind-cluster-config.yaml


### PR DESCRIPTION
I've separated `ingress-controller` and `acp-stack` into separate make targets so it's possible to install everything without acp in one step.

This is useful when we're developing our helm charts. We can run `make prepare` to set up prerequisites and then run `helm install...` from local directory.