### PR TITLE
Bump kind to 0.11.1 in github actions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Kubernetes
         uses: engineerd/setup-kind@v0.5.0
         with:
-          version: "v0.10.0"
+          version: "v0.11.1"
       - uses: azure/setup-helm@v1
         with:
           version: 3.5.4


### PR DESCRIPTION
Github actions fails with kind 0.10.0.
Works fine for 0.11.1