### PR TITLE
Create a dockerconfigjson secret for docker.cloudentity.io

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,10 @@ prepare-cluster:
 		--docker-server=acp.artifactory.cloudentity.com \
 		--docker-username=${DOCKER_USER} \
 		--docker-password=${DOCKER_PWD}
+	kubectl create -n acp-system secret docker-registry docker.cloudentity.io \
+		--docker-server=docker.cloudentity.io \
+		--docker-username=${DOCKER_USER} \
+		--docker-password=${DOCKER_PWD}
 
 install-ingress-controller:
 	helm upgrade --install ingress-nginx ingress-nginx/ingress-nginx --values ./values/ingress-nginx.yaml -n nginx


### PR DESCRIPTION
## [AUT-3555](https://cloudentity.atlassian.net/browse/AUT-3555)

## Description

Creates a Docker registry secret for docker.cloudentity.io.

This PR creates a secret named "docker.cloudentity.io', the same as the registry's DNS name.
I think this is helpful, because it is obvious which docker registry the secret belongs to:
```
% kubectl -n acp-system get secrets --field-selector type=kubernetes.io/dockerconfigjson
NAME                    TYPE                             DATA   AGE
artifactory             kubernetes.io/dockerconfigjson   1      2d18h
docker.cloudentity.io   kubernetes.io/dockerconfigjson   1      48m
```

## Motivation and Context

We wish to deprecate the Docker registry acp.artifactory.cloudentity.com in favor of docker.cloudentity.io.
This avoids the need to create a secret manually, when deploying ACP Helm charts to acp-on-k8s.

## Types of changes
<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

* [x] Bugfix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] Tests (extending the test suite)
* [ ] Documentation Update (if none of the other choices apply)

## How has this been tested?

In cloudentity/acp-on-k8s/Makefile, the `prepare-cluster` target should succeed.

In cloudentity/acp-help-charts,	install	a chart	that pulls from a docker.cloudentity.io repository,
and uses the secret 'docker.cloudentity.io', for example:
```
image:
  repository: docker.cloudentity.io/kong-authorizer
  pullPolicy: IfNotPresent
  tag: "latest"

imagePullSecrets:
  - name: docker.cloudentity.io
```
The chart should deploy successfully.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
* [x] My code follows the code style of this project.
* [ ] I have added tests to cover my changes
* [ ] All new and existing tests passed
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
