### PR TITLE
[DEVOPS-723] removing "artifactory" secret

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,10 +19,6 @@ prepare-helm:
 prepare-cluster:
 	kubectl create namespace acp-system
 	kubectl create namespace nginx
-	kubectl create -n acp-system secret docker-registry artifactory \
-		--docker-server=docker.cloudentity.io \
-		--docker-username=${DOCKER_USER} \
-		--docker-password=${DOCKER_PWD}
 	kubectl create -n acp-system secret docker-registry docker.cloudentity.io \
 		--docker-server=docker.cloudentity.io \
 		--docker-username=${DOCKER_USER} \

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ prepare-cluster:
 	kubectl create namespace acp-system
 	kubectl create namespace nginx
 	kubectl create -n acp-system secret docker-registry artifactory \
-		--docker-server=acp.artifactory.cloudentity.com \
+		--docker-server=docker.cloudentity.io \
 		--docker-username=${DOCKER_USER} \
 		--docker-password=${DOCKER_PWD}
 	kubectl create -n acp-system secret docker-registry docker.cloudentity.io \


### PR DESCRIPTION
## Description
Removed the `artifactory` secret as it's no longer used after changes in helm charts introduced in https://github.com/cloudentity/acp-helm-charts/pull/107

## Type of changes

[] Bugfix (non-breaking change which fixes an issue)
[] New feature (non-breaking change which adds functionality)
[] Tests (extending the test suite)
[x] Refactor (internal improvement that doesn't change product functionality)
[] Other (if none of the other choices apply)
