### PR TITLE
Removed not intuitive nginx uninstall from uninstall-acp

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,6 @@ watch:
 
 uninstall-acp:
 	helm uninstall acp -n acp-system
-	helm uninstall ingress-nginx -n nginx
 
 delete-cluster:
 	kind delete cluster --name=acp


### PR DESCRIPTION
Changed uninstall-acp to match setup behaviour.

As for now:
- make prepare - deploys nginx and other basic services.
- make install-acp-stack - deploys acp
- make uninstall-acp - uninstall acp AND nginx