### PR TITLE
Changed tests version to 1.16.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,7 +106,7 @@ debug:
 
 ## tests
 
-TEST_DOCKER_VERSION=1.16.2
+TEST_DOCKER_VERSION=1.16.1
 
 test-prepare-grid:
 	docker run -d --rm \

--- a/Makefile
+++ b/Makefile
@@ -106,7 +106,7 @@ debug:
 
 ## tests
 
-TEST_DOCKER_VERSION=latest
+TEST_DOCKER_VERSION=1.16.2
 
 test-prepare-grid:
 	docker run -d --rm \


### PR DESCRIPTION
Latest works for 2.0 candidates (due to breaking changes).
In helm-charts we still use 1.16.1 (next one would be 1.17.0) which is not compatible with latest tests version.