### PR TITLE
AUT-7075 Upgrade Istio to version 1.14.4, to be compatible with kubernetes 1.24

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,13 +21,13 @@ jobs:
         with:
           version: 3.5.4
         id: install
+      - name: Login to docker.cloudentity.io
+        run: echo "${{ secrets.DOCKER_PWD }}" | docker login docker.cloudentity.io -u "${{ secrets.DOCKER_USER }}" --password-stdin
       - name: Deploy
         env: # Or as an environment variable
           DOCKER_USER: ${{ secrets.DOCKER_USER }}
           DOCKER_PWD: ${{ secrets.DOCKER_PWD }}
         run: make all
-      - name: Login to docker.cloudentity.io
-        run: echo "${{ secrets.DOCKER_PWD }}" | docker login docker.cloudentity.io -u "${{ secrets.DOCKER_USER }}" --password-stdin
       - name: Test
         run: make test-prepare test-web-smoke
       - name: Test-clean

--- a/Makefile
+++ b/Makefile
@@ -149,7 +149,7 @@ debug:
 
 ## tests
 
-TEST_DOCKER_VERSION=2.8.0
+TEST_DOCKER_VERSION=2.7.0
 
 test-prepare-grid:
 	docker run --detach --rm \

--- a/Makefile
+++ b/Makefile
@@ -196,4 +196,3 @@ graphql-demo:
 	--wait
 
 	make install-countries
-

--- a/Makefile
+++ b/Makefile
@@ -140,9 +140,9 @@ check-acp-server-responsivness:
 debug:
 	-kubectl get all --all-namespaces
 	-kubectl logs daemonset/kindnet --namespace kube-system
-	-kubectl daemonset/kube-proxy --namespace kube-system
-	-kubectl deploy/acp --namespace kube-system
-	-kubectl deploy/ingress-nginx-controller --namespace kube-system
+	-kubectl logs daemonset/kube-proxy --namespace kube-system
+	-kubectl logs deploy/acp --namespace kube-system
+	-kubectl logs deploy/ingress-nginx-controller --namespace kube-system
 	-kubectl logs deploy/coredns --namespace kube-system
 	-kubectl logs deploy/local-path-provisioner --namespace local-path-storage
 	-kubectl describe pod --selector app.kubernetes.io/name=acp --namespace acp-system

--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ install-acp-stack:
 	helm upgrade acp ${KUBE_ACP_STACK_CHART} \
 		--values ./values/kube-acp-stack.yaml \
 		--namespace acp-system \
-		--timeout 10m \
+		--timeout 11m \
 		--install
 
 install-istio-authorizer:

--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ install-acp-stack:
 	helm upgrade acp ${KUBE_ACP_STACK_CHART} \
 		--values ./values/kube-acp-stack.yaml \
 		--namespace acp-system \
-		--timeout 10m \
+		--timeout 15m \
 		--install
 
 install-istio-authorizer:

--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ install-acp-stack:
 	helm upgrade acp ${KUBE_ACP_STACK_CHART} \
 		--values ./values/kube-acp-stack.yaml \
 		--namespace acp-system \
-		--timeout 15m \
+		--timeout 30m \
 		--install
 
 install-istio-authorizer:

--- a/Makefile
+++ b/Makefile
@@ -149,16 +149,16 @@ debug:
 
 ## tests
 
-TEST_DOCKER_VERSION=2.7.0
+TEST_DOCKER_VERSION=2.8.0
 
 test-prepare-grid:
 	docker run --detach --rm \
-		--volume /dev/shm:/dev/shm \
-		--memory 2048M \
-		--name standalone-chrome \
+		--name selenium-grid-hub \
 		--network host \
 		--add-host acp.acp-system:127.0.0.1 \
-		selenium/standalone-chrome:3.141.59
+		--volume /dev/shm:/dev/shm \
+		--memory 2048M \
+		selenium/hub:4.2.2-20220609
 
 test-prepare-runner:
 	docker pull docker.cloudentity.io/acceptance-tests:${TEST_DOCKER_VERSION}
@@ -166,7 +166,7 @@ test-prepare-runner:
 		--name test-runner \
 		--network host \
 		--add-host acp.acp-system:127.0.0.1 \
-		--add-host standalone-chrome:127.0.0.1 \
+		--add-host selenium-grid-hub:127.0.0.1 \
 		--user 1000:1000 \
 		docker.cloudentity.io/acceptance-tests:${TEST_DOCKER_VERSION} /bin/sh
 

--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ install-acp-stack:
 	helm upgrade acp ${KUBE_ACP_STACK_CHART} \
 		--values ./values/kube-acp-stack.yaml \
 		--namespace acp-system \
-		--timeout 8m \
+		--timeout 10m \
 		--install
 
 install-istio-authorizer:

--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ install-acp-stack:
 	helm upgrade acp ${KUBE_ACP_STACK_CHART} \
 		--values ./values/kube-acp-stack.yaml \
 		--namespace acp-system \
-		--timeout 5m \
+		--timeout 8m \
 		--install
 
 install-istio-authorizer:

--- a/Makefile
+++ b/Makefile
@@ -196,3 +196,4 @@ graphql-demo:
 	--wait
 
 	make install-countries
+

--- a/Makefile
+++ b/Makefile
@@ -149,7 +149,7 @@ debug:
 
 ## tests
 
-TEST_DOCKER_VERSION=bbfd227
+TEST_DOCKER_VERSION=2.8.0
 
 test-prepare-grid:
 	docker run --detach --rm \

--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ install-acp-stack:
 	helm upgrade acp ${KUBE_ACP_STACK_CHART} \
 		--values ./values/kube-acp-stack.yaml \
 		--namespace acp-system \
-		--timeout 30m \
+		--timeout 10m \
 		--install
 
 install-istio-authorizer:

--- a/Makefile
+++ b/Makefile
@@ -70,10 +70,10 @@ install-istio-authorizer:
 		--wait
 
 install-istio:
-	curl --location https://istio.io/downloadIstio | ISTIO_VERSION=1.9.3 TARGET_ARCH=x86_64  sh -
-	./istio-1.9.3/bin/istioctl install --filename ./config/ce-istio-profile.yaml --skip-confirmation
+	curl --location https://istio.io/downloadIstio | ISTIO_VERSION=1.14.4 TARGET_ARCH=x86_64  sh -
+	./istio-1.14.4/bin/istioctl install --filename ./config/ce-istio-profile.yaml --skip-confirmation
 	kubectl label namespace default istio-injection=enabled
-	rm --recursive --force ./istio-1.9.3
+	rm -r -f ./istio-1.14.4
 
 wait-acp:
 	kubectl wait deploy/acp \
@@ -194,5 +194,5 @@ graphql-demo:
 	--timeout 5m \
 	--install \
 	--wait
- 
+
 	make install-countries


### PR DESCRIPTION

## [AUT-7075](https://cloudentity.atlassian.net/browse/AUT-7075)

## Description

The `install-istio` Makefile target was failing, because Istio 1.9.3 is not compatible with our current kubernetes version 1.24. This PR upgrades Istio to version 1.14.4.

## Information for QA
<!-- [Place an '[X]' (no spaces) in all applicable fields.] -->
- [ ] Is QA testing required?
- [ ] Does PR contain unit tests?
- [ ] Should QA create E2E tests for the change?
