### PR TITLE
Addressed the know issue for timescale db

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,7 @@ prepare-cluster:
 		--docker-server docker.cloudentity.io \
 		--docker-username ${DOCKER_USER} \
 		--docker-password ${DOCKER_PWD}
+	kubectl apply -f ./config/timescale-role-binding.yaml
 
 install-ingress-controller:
 	helm upgrade ingress-nginx ingress-nginx/ingress-nginx \

--- a/config/timescale-role-binding.yaml
+++ b/config/timescale-role-binding.yaml
@@ -1,0 +1,22 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: timescaledb-patch-to-remove
+  namespace: acp-system
+rules:
+- apiGroups: [""] # "" indicates the core API group
+  resources: ["services"]
+  verbs: ["create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: timescaledb-patch-binding
+  namespace: acp-system
+subjects:
+- kind: ServiceAccount
+  name: timescale
+roleRef:
+  kind: Role
+  name: timescaledb-patch-to-remove
+  apiGroup: rbac.authorization.k8s.io

--- a/values/kube-acp-stack.yaml
+++ b/values/kube-acp-stack.yaml
@@ -68,3 +68,7 @@ acp:
               path: /test
               policy_id: block
               can_have_policy: true
+  config:
+    data:
+      timescale:
+        url: postgres://postgres:PaSsW0rD@timescale.acp-system.svc.cluster.local/postgres?sslmode=require


### PR DESCRIPTION
## Jira task - https://cloudentity.atlassian.net/browse/AUT-8383

## Implementation details (internal)
Addressed the know issue for timescale db by adding a role and role-binding as suggested in here: https://github.com/timescale/helm-charts/issues/405#issuecomment-1298789521. Going further, updated the connection string used by acp to connect to timescale db to use acp-system namespace instead of default.

## Information for QA

<!-- [Place an '[X]' (no spaces) in all applicable fields.] -->

- [ ] Is QA testing required?
- [ ] Does PR contain unit tests?
- [ ] Should QA create E2E tests for the change?

## Additional QA Procedures (Optional)

<!--- Describe what QA needs to do if needed -->

## Screenshots (if appropriate):
