### PR TITLE
Scripts to launch ACP stack with additional tenants and to exercise the Istio authorizer

### DIFF
--- a/scripts/add_tenants.sh
+++ b/scripts/add_tenants.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# Use this script before 'make install-acp-stack' to add extra tenants.
+# NOTE that after using make uninstall-acp, i had to delete the Service "timescale-config", before i could re-run install-acp-stack.
+
+NUM=${1:-1}
+
+cat <<EOT >> ../values/kube-acp-stack.yaml
+      tenants:
+EOT
+for I in `seq 1 $NUM`
+do
+    cat <<EOT >> ../values/kube-acp-stack.yaml
+        - id: tid-$I
+          name: tid-$I
+EOT
+done
+
+cat <<EOT >> ../values/kube-acp-stack.yaml
+      servers:
+EOT
+for I in `seq 1 $NUM`
+do
+    cat <<EOT >> ../values/kube-acp-stack.yaml
+        - id: default
+          tenant_id: tid-$I
+EOT
+done

--- a/scripts/ping_istio.sh
+++ b/scripts/ping_istio.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+# This script assumes that you have installed the istio-authorizer in multi-tenant authorizer mode,
+# and set up ACP with with additional tenants. See add_tenants.sh in this directory to create the
+# additional tenants when you make install-acp-stack.
+#
+# This script also assumes that you have installed the httpbin example and the sleep pod, as described in:
+#
+#   https://cloudentity.com/developers/howtos/enforcement/istio/
+#
+# There is a concise guide to setting this up, which also adds instructions how to deploy the istio-authorizer
+# from a custom Docker image, in cloudentity/acp/cmd/istio/README.me.
+#
+# For each tenant, this script constructs a token with the claims tid and aid corresponding to the tenant,
+# and then sends a request from the sleep pod that will be authorized (or not) by the istio-authorizer.
+# The token's tid claim  will force the creation of an authorizer for that tenant in the istio-authorizer.
+#
+# Usage:
+#
+#   ping_istio.sh $NUM [ loop ]
+#
+# $NUM can be between 1 and the number of tenants you added with add_tenants.sh
+# Add 'loop' if you want to cycle continuously, otherwise it will ping tenants tid-1 .. tid-$NUM once and exit.
+#
+NUM=${1:-1}
+OPT=${2}
+
+base64_encode()
+{
+	declare input=${1:-$(</dev/stdin)}
+	# Use `tr` to URL encode the output from base64.
+	printf '%s' "${input}" | base64 | tr -d '=' | tr '/+' '_-' | tr -d '\n'
+}
+
+SLEEP=`kubectl get pod -l app=sleep -o jsonpath={.items..metadata.name}`
+
+while true
+do
+    for IX in `seq 1 $NUM`
+    do
+        tid=tid-$IX
+        aid=default
+
+        # This token only has to parse, it does not need to verify.
+        TOKEN=$(base64_encode <<<'{"typ":"JWT","alg":"HS256"}').$(base64_encode <<<'{"tid":"'$tid'","aid":"'$aid'"}').ffff
+
+        kubectl exec -it $SLEEP --container sleep -- curl -s -D - -H "Authorization: bearer $TOKEN" http://httpbin.default:80/anything > /dev/null
+        echo -n .
+    done
+    if [ "$OPT" != "loop" ] ; then break ; fi
+    echo loop
+done

--- a/values/kube-acp-stack.yaml
+++ b/values/kube-acp-stack.yaml
@@ -22,6 +22,10 @@ acp:
   features:
     integration_endpoints: true
     swagger_ui: true
+  config:
+    data:
+      timescale:
+        url: postgres://postgres:PaSsW0rD@timescale.acp-system.svc.cluster.local/postgres?sslmode=require
   importJob:
     enabled: true
     data:
@@ -68,7 +72,3 @@ acp:
               path: /test
               policy_id: block
               can_have_policy: true
-  config:
-    data:
-      timescale:
-        url: postgres://postgres:PaSsW0rD@timescale.acp-system.svc.cluster.local/postgres?sslmode=require


### PR DESCRIPTION

## Jira task - [SUP-2908](https://cloudentity.atlassian.net/browse/SUP-2908)

## Release Notes Description (public)

## Implementation details (internal)

This PR adds some scripts that are helpful to test the Istio Authorizer.
The general approach is first run add some number of tenants:

```
cd scripts ; ./add_tenants.sh 100 ; cd ..
```
Then set up the Kind cluster with ACP, Istio, Istio-Authorizer and examples, as described in 
https://github.com/cloudentity/acp/blob/dev/cmd/istio/README.md

Then force the istio authorizer to create a sub-authorizer for each tenant, by running `ping_istio.sh`
```
scripts/ping_istio.sh 100
```
`ping_istio.sh` has an option to loop, in order to keep all of the sub-authorizers alive.
```
scripts/ping_istio.sh 100 loop
```

## Information for QA

<!-- [Place an '[X]' (no spaces) in all applicable fields.] -->

- [ ] Is QA testing required?
- [ ] Does PR contain unit tests?
- [ ] Should QA create E2E tests for the change?



[SUP-2908]: https://cloudentity.atlassian.net/browse/SUP-2908?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ