### PR TITLE
legacy - istio adjustment for mac-related issues

### DIFF
--- a/config/ce-istio-profile.yaml
+++ b/config/ce-istio-profile.yaml
@@ -13,6 +13,19 @@ spec:
     - name: istio-egressgateway
       enabled: true
       k8s:
+        #workoaround for mac
+        overlays:
+          - kind: Deployment
+            name: istio-egressgateway
+            patches:
+              - path: 'spec.template.spec.volumes[100]'
+                value:
+                  name: temp
+                  emptyDir: {}
+              - path: 'spec.template.spec.containers[0].volumeMounts[100]'
+                value:
+                  mountPath: /tmp
+                  name: temp
         resources:
           requests:
             cpu: 10m
@@ -22,6 +35,19 @@ spec:
     - name: istio-ingressgateway
       enabled: true
       k8s:
+        #workoaround for mac
+        overlays:
+          - kind: Deployment
+            name: istio-ingressgateway
+            patches:
+              - path: 'spec.template.spec.volumes[100]'
+                value:
+                  name: temp
+                  emptyDir: {}
+              - path: 'spec.template.spec.containers[0].volumeMounts[100]'
+                value:
+                  mountPath: /tmp
+                  name: temp
         resources:
           requests:
             cpu: 10m
@@ -75,7 +101,6 @@ spec:
 
     pilot:
       autoscaleEnabled: false
-
     gateways:
       istio-egressgateway:
         autoscaleEnabled: false


### PR DESCRIPTION
It's needed to proceed with deployment of istio otherwise there are problems like:
``` assertion failed [!result.is_error]: Failed to create temporary file                                                           ││ (ThreadContextFcntl.cpp:84 create_tempfile)                                                                                    ││ 2024-07-24T09:21:51.154051Z    error    Epoch 0 exited with error: signal: trace/breakpoint trap                               ││ 2024-07-24T09:21:51.154082Z    info    No more active epochs, terminating```